### PR TITLE
Add author and contributors to About section

### DIFF
--- a/src/Components/Pages/Settings.lua
+++ b/src/Components/Pages/Settings.lua
@@ -163,6 +163,18 @@ local function Page(_, hooks)
 					formItem = true,
 					order = 10,
 				}),
+				author = e(Layout.Forms.Section, {
+					heading = "Author",
+					hint = Config.Author,
+					formItem = true,
+					order = 11,
+				}),
+				contributors = e(Layout.Forms.Section, {
+					heading = "Contributors",
+					hint = table.concat(Config.Contributors, ", "),
+					formItem = true,
+					order = 12,
+				}),
 			}),
 		}),
 	})

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -1,4 +1,8 @@
+local HttpService = game:GetService("HttpService")
 local PluginDebugService = game:GetService("PluginDebugService")
+
+local repo = "csqrl/roactify-plugin"
+local publishedId = "4749111907"
 
 local plugin = script:FindFirstAncestorOfClass("Plugin")
 local pluginId = plugin.Name:match("%d+$")
@@ -6,11 +10,29 @@ local pluginId = plugin.Name:match("%d+$")
 local Config = {
 	Version = "1.0.0",
 	VersionTag = "Public",
+	Author = string.match(repo, "^[^/]+"),
+	Contributors = {},
 }
+
+local contribSuccess, contribResponse = pcall(HttpService.RequestAsync, HttpService, {
+	Url = "https://api.github.com/repos/"..repo.."/contributors?anon=1",
+	Method = "GET",
+})
+if contribSuccess and contribResponse.Success then
+	local jsonSuccess, data = pcall(HttpService.JSONDecode, HttpService, contribResponse.Body)
+	if jsonSuccess and data then
+		for i, contributor in ipairs(data) do
+			local name = contributor.login or contributor.name
+			if name == Config.Author then continue end
+
+			Config.Contributors[i] = name
+		end
+	end
+end
 
 if plugin.Parent == PluginDebugService then
 	Config.VersionTag = "Dev"
-elseif pluginId ~= "4749111907" then
+elseif pluginId ~= publishedId then
 	Config.VersionTag = "Canary"
 end
 


### PR DESCRIPTION
My goal with this is to make this plugin easy to contribute and fork.
- Uses GitHub's API to grab repo contributors and author and displays them in the About section.
- Makes it easier to fork by avoiding hardcoding repo or plugin ID.

![image](https://user-images.githubusercontent.com/40185666/153465440-f1028ac3-80e8-44ac-987b-802a248b3001.png)
